### PR TITLE
add zip64 support

### DIFF
--- a/test/make-testdata.sh
+++ b/test/make-testdata.sh
@@ -33,5 +33,11 @@ ALLTMPFILES=('empty file with spaces' \
 ( cd "$TMPDIR" && 7z a "$OUTDIR/7z-utf8.zip" "$UTF8NAME" -mcu=on )
 ( cd "$TMPDIR" && zip "$OUTDIR/zip-utf8.zip" "$UTF8NAME" )
 
+
+dd if=/dev/zero bs=1000000 count=5000 > "$TMPDIR/more.than.FFFFFFFF"
+( cd "$TMPDIR" && zip -r -0 "$OUTDIR/zip64.zip" "more.than.FFFF" "more.than.FFFFFFFF" "100.dat")
+
 # Clean up.
 rm -f "${ALLTMPFILES[@]}" "$UTF8NAME"
+
+


### PR DESCRIPTION
Hi, thanks for making this little library, has been really helpful!

I was integrating this into another library, and wanted to add zip64 support.
Wanted to contribute this back to zipinfo in case its useful for anyone..

The tests create a 5GB file, tested this on OS X, there may be other issues where it wouldn't work.. But hopefully will be useful for someone!